### PR TITLE
Peacoqc-rs PyO3 bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,13 @@ node_modules/
 .DS_Store
 Thumbs.db
 
+# Python
+.venv/
+__pycache__/
+*.pyc
+*.so
+*.pyd
+
 # Env
 .env
 .env.*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5110,6 +5110,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "metal"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6004,6 +6013,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "peacoqc-py"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "flow-fcs",
+ "peacoqc-rs",
+ "polars",
+ "pyo3",
+ "pyo3-polars",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "peacoqc-rs"
 version = "0.2.4"
 dependencies = [
@@ -6438,6 +6460,7 @@ dependencies = [
  "object_store",
  "parking_lot",
  "polars-arrow-format",
+ "pyo3",
  "regex",
  "signal-hook 0.4.3",
  "simdutf8",
@@ -6467,6 +6490,16 @@ dependencies = [
  "recursive",
  "regex",
  "version_check",
+]
+
+[[package]]
+name = "polars-ffi"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9526b18335cfddc556eb5c34cdecba3ecf49bba7734470a82728569d44e72a0"
+dependencies = [
+ "polars-arrow",
+ "polars-core",
 ]
 
 [[package]]
@@ -7024,6 +7057,84 @@ dependencies = [
  "num-traits 0.2.19",
  "pest",
  "pest_derive",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
+dependencies = [
+ "indoc",
+ "libc",
+ "memoffset",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
+dependencies = [
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "pyo3-polars"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29248c4baefdfa23a7768341d1e431a5dee7348a757fa74315c810f3b8710d4"
+dependencies = [
+ "libc",
+ "once_cell",
+ "polars",
+ "polars-arrow",
+ "polars-core",
+ "polars-error",
+ "polars-ffi",
+ "pyo3",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -8537,6 +8648,12 @@ dependencies = [
  "libc",
  "xattr",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tch"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "gates",
     "peacoqc-rs",
     "peacoqc-cli",
+    "peacoqc-py",
     "tru-ols",
     "tru-ols-cli",
     "utils",

--- a/peacoqc-py/Cargo.toml
+++ b/peacoqc-py/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "peacoqc-py"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Python bindings for peacoqc-rs flow cytometry QC"
+repository = "https://github.com/jrmoynihan/flow/peacoqc-py"
+keywords = [
+    "flow-cytometry",
+    "quality-control",
+    "bioinformatics",
+    "peacoqc",
+    "python",
+]
+categories = ["science", "algorithms"]
+
+[lib]
+name = "peacoqc"
+crate-type = ["cdylib"]
+
+[dependencies]
+peacoqc-rs = { path = "../peacoqc-rs", default-features = false, features = ["flow-fcs"] }
+flow-fcs = { path = "../fcs", version = "^0.2.2" }
+polars = { workspace = true }
+pyo3 = { version = "0.27", features = ["extension-module"] }
+pyo3-polars = { version = "0.26", features = ["dtype-full"] }
+thiserror.workspace = true
+anyhow.workspace = true

--- a/peacoqc-py/pyproject.toml
+++ b/peacoqc-py/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "peacoqc"
+version = "0.1.0"
+description = "Python bindings for peacoqc-rs flow cytometry quality control"
+requires-python = ">=3.9"
+license = "MIT"
+keywords = ["flow-cytometry", "quality-control", "bioinformatics", "peacoqc"]
+classifiers = [
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+]
+dependencies = ["polars>=1.0"]
+
+[tool.maturin]
+manifest-path = "Cargo.toml"
+python-source = "python"
+features = ["pyo3/extension-module"]

--- a/peacoqc-py/python/peacoqc/__init__.py
+++ b/peacoqc-py/python/peacoqc/__init__.py
@@ -1,0 +1,27 @@
+"""
+peacoqc - Python bindings for peacoqc-rs flow cytometry quality control.
+
+This package provides Python access to the high-performance Rust implementation
+of the PeacoQC algorithm for automated quality control of flow cytometry data.
+
+Usage:
+    import polars as pl
+    import peacoqc
+
+    # Load your data as a polars DataFrame
+    df = pl.read_csv("events.csv")
+
+    # Run PeacoQC quality control
+    result = peacoqc.run_qc(
+        df,
+        channels=["FL1-A", "FL2-A"],
+        channel_ranges={"FL1-A": (0.0, 262144.0), "FL2-A": (0.0, 262144.0)},
+    )
+    print(f"Removed {result.percentage_removed:.2f}% of events")
+
+    # Apply the mask to filter good cells
+    good_mask = result.good_cells
+    clean_df = df.filter(pl.Series(good_mask))
+"""
+
+from .peacoqc import *  # noqa: F401, F403

--- a/peacoqc-py/python/peacoqc/peacoqc.pyi
+++ b/peacoqc-py/python/peacoqc/peacoqc.pyi
@@ -1,0 +1,186 @@
+"""Type stubs for the peacoqc native module."""
+
+from __future__ import annotations
+
+import polars as pl
+
+class QCResult:
+    """Result of the PeacoQC quality control algorithm."""
+
+    @property
+    def good_cells(self) -> list[bool]:
+        """Boolean list: True = keep, False = remove."""
+        ...
+    @property
+    def percentage_removed(self) -> float:
+        """Percentage of events removed."""
+        ...
+    @property
+    def it_percentage(self) -> float | None:
+        """Isolation Tree percentage (if used)."""
+        ...
+    @property
+    def mad_percentage(self) -> float | None:
+        """MAD percentage (if used)."""
+        ...
+    @property
+    def consecutive_percentage(self) -> float:
+        """Consecutive filtering percentage."""
+        ...
+    @property
+    def n_bins(self) -> int:
+        """Number of bins used."""
+        ...
+    @property
+    def events_per_bin(self) -> int:
+        """Events per bin."""
+        ...
+
+class MarginResult:
+    """Result of margin removal."""
+
+    @property
+    def mask(self) -> list[bool]:
+        """Boolean mask: True = keep, False = margin event."""
+        ...
+    @property
+    def percentage_removed(self) -> float:
+        """Total percentage of events removed."""
+        ...
+    @property
+    def margin_matrix(self) -> dict[str, tuple[int, int]]:
+        """Per-channel removal counts: {channel: (min_removed, max_removed)}."""
+        ...
+
+class DoubletResult:
+    """Result of doublet removal."""
+
+    @property
+    def mask(self) -> list[bool]:
+        """Boolean mask: True = keep, False = doublet."""
+        ...
+    @property
+    def percentage_removed(self) -> float:
+        """Percentage of events removed."""
+        ...
+    @property
+    def median_ratio(self) -> float:
+        """Median ratio used."""
+        ...
+    @property
+    def mad_ratio(self) -> float:
+        """MAD of ratios."""
+        ...
+    @property
+    def threshold(self) -> float:
+        """Threshold used for doublet detection."""
+        ...
+
+class FcsFile:
+    """Wrapper for an FCS file loaded from disk."""
+
+    @staticmethod
+    def open(path: str) -> FcsFile:
+        """Open an FCS file from disk."""
+        ...
+    @property
+    def n_events(self) -> int:
+        """Number of events in the file."""
+        ...
+    @property
+    def channel_names(self) -> list[str]:
+        """Channel names."""
+        ...
+    @property
+    def fluorescence_channels(self) -> list[str]:
+        """Fluorescence channel names (auto-detected, excluding FSC/SSC/Time)."""
+        ...
+    @property
+    def dataframe(self) -> pl.DataFrame:
+        """Return the event data as a polars DataFrame."""
+        ...
+    def has_compensation(self) -> bool:
+        """Whether compensation info ($SPILLOVER) exists."""
+        ...
+
+def run_qc(
+    df: pl.DataFrame,
+    channels: list[str],
+    channel_ranges: dict[str, tuple[float, float]],
+    mode: str = "all",
+    mad: float = 6.0,
+    it_limit: float = 0.6,
+    consecutive_bins: int = 5,
+    min_cells: int = 150,
+    max_bins: int = 500,
+    events_per_bin: int | None = None,
+    remove_zeros: bool = False,
+    peak_removal: float | None = None,
+) -> QCResult:
+    """Run the PeacoQC quality control algorithm on a polars DataFrame."""
+    ...
+
+def remove_margins(
+    df: pl.DataFrame,
+    channels: list[str],
+    channel_ranges: dict[str, tuple[float, float]],
+    remove_min: list[str] | None = None,
+    remove_max: list[str] | None = None,
+) -> MarginResult:
+    """Remove margin events from flow cytometry data."""
+    ...
+
+def remove_doublets(
+    df: pl.DataFrame,
+    channel_ranges: dict[str, tuple[float, float]],
+    channel1: str = "FSC-A",
+    channel2: str = "FSC-H",
+    nmad: float = 4.0,
+    b: float = 0.0,
+) -> DoubletResult:
+    """Remove doublet events based on area/height scatter ratio."""
+    ...
+
+def read_fcs(path: str) -> pl.DataFrame:
+    """Open an FCS file and return its data as a polars DataFrame."""
+    ...
+
+def run_qc_on_fcs(
+    path: str,
+    channels: list[str] | None = None,
+    apply_compensation: bool = True,
+    apply_transformation: bool = True,
+    mode: str = "all",
+    mad: float = 6.0,
+    it_limit: float = 0.6,
+    consecutive_bins: int = 5,
+) -> tuple[QCResult, pl.DataFrame]:
+    """Open an FCS file, preprocess, and run PeacoQC in one step."""
+    ...
+
+def open_fcs(path: str) -> FcsFile:
+    """Open an FCS file as an FcsFile object."""
+    ...
+
+def run_qc_on_fcs_obj(
+    fcs: FcsFile,
+    channels: list[str] | None = None,
+    mode: str = "all",
+    mad: float = 6.0,
+    it_limit: float = 0.6,
+    consecutive_bins: int = 5,
+) -> QCResult:
+    """Run PeacoQC directly on an FcsFile object."""
+    ...
+
+def preprocess(
+    fcs: FcsFile,
+    apply_compensation: bool = True,
+    apply_transformation: bool = True,
+) -> FcsFile:
+    """Preprocess an FCS file (compensation + transformation)."""
+    ...
+
+def filter_fcs(fcs: FcsFile, mask: list[bool]) -> FcsFile:
+    """Filter an FcsFile by a boolean mask, returning a new FcsFile."""
+    ...

--- a/peacoqc-py/src/lib.rs
+++ b/peacoqc-py/src/lib.rs
@@ -1,0 +1,677 @@
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3_polars::PyDataFrame;
+use std::collections::HashMap;
+
+use peacoqc_rs::{
+    DoubletConfig, DoubletResult as RsDoubletResult, FcsFilter, MarginConfig,
+    MarginResult as RsMarginResult, PeacoQCConfig, PeacoQCData,
+    PeacoQCResult as RsPeacoQCResult, QCMode,
+};
+
+// ---------------------------------------------------------------------------
+// Internal wrapper: implements PeacoQCData over a polars DataFrame + metadata
+// ---------------------------------------------------------------------------
+
+struct DataFrameQCData {
+    df: polars::frame::DataFrame,
+    channel_ranges: HashMap<String, (f64, f64)>,
+}
+
+impl PeacoQCData for DataFrameQCData {
+    fn n_events(&self) -> usize {
+        self.df.height()
+    }
+
+    fn channel_names(&self) -> Vec<String> {
+        self.df
+            .get_column_names()
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    fn get_channel_range(&self, channel: &str) -> Option<(f64, f64)> {
+        self.channel_ranges.get(channel).copied()
+    }
+
+    fn get_channel_f64(&self, channel: &str) -> peacoqc_rs::Result<Vec<f64>> {
+        let series = self
+            .df
+            .column(channel)
+            .map_err(|_| peacoqc_rs::PeacoQCError::ChannelNotFound(channel.to_string()))?;
+
+        if let Ok(f64_vals) = series.f64() {
+            Ok(f64_vals.into_iter().flatten().collect())
+        } else if let Ok(f32_vals) = series.f32() {
+            Ok(f32_vals
+                .into_iter()
+                .flatten()
+                .map(|v| v as f64)
+                .collect())
+        } else {
+            Err(peacoqc_rs::PeacoQCError::InvalidChannel(format!(
+                "Channel {channel} is not numeric (dtype: {:?})",
+                series.dtype()
+            )))
+        }
+    }
+}
+
+impl FcsFilter for DataFrameQCData {
+    fn filter(&self, mask: &[bool]) -> peacoqc_rs::Result<Self> {
+        use polars::prelude::*;
+        let mask_series = Series::new("mask".into(), mask.to_vec());
+        let mask_ca = mask_series.bool().map_err(|e| {
+            peacoqc_rs::PeacoQCError::StatsError(format!(
+                "Failed to create boolean mask: {e}"
+            ))
+        })?;
+        let filtered = self.df.filter(mask_ca).map_err(peacoqc_rs::PeacoQCError::PolarsError)?;
+        Ok(DataFrameQCData {
+            df: filtered,
+            channel_ranges: self.channel_ranges.clone(),
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: convert PeacoQCError → PyErr
+// ---------------------------------------------------------------------------
+
+fn to_py_err(e: peacoqc_rs::PeacoQCError) -> PyErr {
+    PyValueError::new_err(e.to_string())
+}
+
+fn anyhow_to_py_err(e: anyhow::Error) -> PyErr {
+    PyValueError::new_err(e.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Python-visible result types
+// ---------------------------------------------------------------------------
+
+/// Result of the PeacoQC quality control algorithm.
+#[pyclass(name = "QCResult")]
+#[derive(Clone)]
+struct PyQCResult {
+    inner: RsPeacoQCResult,
+}
+
+#[pymethods]
+impl PyQCResult {
+    /// Boolean list: True = keep, False = remove.
+    #[getter]
+    fn good_cells(&self) -> Vec<bool> {
+        self.inner.good_cells.clone()
+    }
+
+    /// Percentage of events removed.
+    #[getter]
+    fn percentage_removed(&self) -> f64 {
+        self.inner.percentage_removed
+    }
+
+    /// Isolation Tree percentage (if used).
+    #[getter]
+    fn it_percentage(&self) -> Option<f64> {
+        self.inner.it_percentage
+    }
+
+    /// MAD percentage (if used).
+    #[getter]
+    fn mad_percentage(&self) -> Option<f64> {
+        self.inner.mad_percentage
+    }
+
+    /// Consecutive filtering percentage.
+    #[getter]
+    fn consecutive_percentage(&self) -> f64 {
+        self.inner.consecutive_percentage
+    }
+
+    /// Number of bins used.
+    #[getter]
+    fn n_bins(&self) -> usize {
+        self.inner.n_bins
+    }
+
+    /// Events per bin.
+    #[getter]
+    fn events_per_bin(&self) -> usize {
+        self.inner.events_per_bin
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "QCResult(removed={:.2}%, bins={}, events_per_bin={})",
+            self.inner.percentage_removed, self.inner.n_bins, self.inner.events_per_bin
+        )
+    }
+}
+
+/// Result of margin removal.
+#[pyclass(name = "MarginResult")]
+#[derive(Clone)]
+struct PyMarginResult {
+    inner: RsMarginResult,
+}
+
+#[pymethods]
+impl PyMarginResult {
+    /// Boolean mask: True = keep, False = margin event.
+    #[getter]
+    fn mask(&self) -> Vec<bool> {
+        self.inner.mask.clone()
+    }
+
+    /// Total percentage of events removed.
+    #[getter]
+    fn percentage_removed(&self) -> f64 {
+        self.inner.percentage_removed
+    }
+
+    /// Per-channel removal counts: {channel: (min_removed, max_removed)}.
+    #[getter]
+    fn margin_matrix(&self) -> HashMap<String, (usize, usize)> {
+        self.inner.margin_matrix.clone()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "MarginResult(removed={:.2}%, channels={})",
+            self.inner.percentage_removed,
+            self.inner.margin_matrix.len()
+        )
+    }
+}
+
+/// Result of doublet removal.
+#[pyclass(name = "DoubletResult")]
+#[derive(Clone)]
+struct PyDoubletResult {
+    inner: RsDoubletResult,
+}
+
+#[pymethods]
+impl PyDoubletResult {
+    /// Boolean mask: True = keep, False = doublet.
+    #[getter]
+    fn mask(&self) -> Vec<bool> {
+        self.inner.mask.clone()
+    }
+
+    /// Percentage of events removed.
+    #[getter]
+    fn percentage_removed(&self) -> f64 {
+        self.inner.percentage_removed
+    }
+
+    /// Median ratio used.
+    #[getter]
+    fn median_ratio(&self) -> f64 {
+        self.inner.median_ratio
+    }
+
+    /// MAD of ratios.
+    #[getter]
+    fn mad_ratio(&self) -> f64 {
+        self.inner.mad_ratio
+    }
+
+    /// Threshold used for doublet detection.
+    #[getter]
+    fn threshold(&self) -> f64 {
+        self.inner.threshold
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "DoubletResult(removed={:.2}%, threshold={:.4})",
+            self.inner.percentage_removed, self.inner.threshold
+        )
+    }
+}
+
+/// Result of opening and optionally preprocessing an FCS file.
+#[pyclass(name = "FcsFile")]
+#[derive(Clone)]
+struct PyFcsFile {
+    inner: flow_fcs::file::Fcs,
+}
+
+#[pymethods]
+impl PyFcsFile {
+    /// Open an FCS file from disk.
+    #[staticmethod]
+    fn open(path: &str) -> PyResult<Self> {
+        let fcs = flow_fcs::file::Fcs::open(path).map_err(|e| {
+            PyValueError::new_err(format!("Failed to open FCS file: {e}"))
+        })?;
+        Ok(PyFcsFile { inner: fcs })
+    }
+
+    /// Number of events in the file.
+    #[getter]
+    fn n_events(&self) -> usize {
+        self.inner.n_events()
+    }
+
+    /// Channel names.
+    #[getter]
+    fn channel_names(&self) -> Vec<String> {
+        self.inner.channel_names()
+    }
+
+    /// Fluorescence channel names (auto-detected, excluding FSC/SSC/Time).
+    #[getter]
+    fn fluorescence_channels(&self) -> Vec<String> {
+        self.inner.get_fluorescence_channels()
+    }
+
+    /// Return the event data as a polars DataFrame.
+    #[getter]
+    fn dataframe(&self) -> PyResult<PyDataFrame> {
+        let df: polars::frame::DataFrame = (*self.inner.data_frame).clone();
+        Ok(PyDataFrame(df))
+    }
+
+    /// Whether compensation info ($SPILLOVER) exists.
+    fn has_compensation(&self) -> bool {
+        self.inner.has_compensation()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "FcsFile(events={}, channels={})",
+            self.inner.n_events(),
+            self.inner.channel_names().len()
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Module-level functions
+// ---------------------------------------------------------------------------
+
+/// Run the PeacoQC quality control algorithm.
+///
+/// Args:
+///     df: polars DataFrame with event data (columns = channels).
+///     channels: list of channel names to analyze.
+///     channel_ranges: dict mapping channel name to (min, max) range tuple.
+///     mode: QC mode - "all" (default), "isolation_tree", "mad", or "none".
+///     mad: MAD threshold multiplier (default 6.0).
+///     it_limit: Isolation Tree gain limit (default 0.6).
+///     consecutive_bins: minimum consecutive good bins (default 5).
+///     min_cells: minimum events per bin (default 150).
+///     max_bins: maximum number of bins (default 500).
+///     events_per_bin: override auto-calculated events per bin.
+///     remove_zeros: remove zeros before peak detection (default False).
+///     peak_removal: peak removal fraction (default 1/3).
+///
+/// Returns:
+///     QCResult with good_cells mask and statistics.
+#[pyfunction]
+#[pyo3(signature = (
+    df,
+    channels,
+    channel_ranges,
+    mode = "all",
+    mad = 6.0,
+    it_limit = 0.6,
+    consecutive_bins = 5,
+    min_cells = 150,
+    max_bins = 500,
+    events_per_bin = None,
+    remove_zeros = false,
+    peak_removal = None,
+))]
+#[allow(clippy::too_many_arguments)]
+fn run_qc(
+    df: PyDataFrame,
+    channels: Vec<String>,
+    channel_ranges: HashMap<String, (f64, f64)>,
+    mode: &str,
+    mad: f64,
+    it_limit: f64,
+    consecutive_bins: usize,
+    min_cells: usize,
+    max_bins: usize,
+    events_per_bin: Option<usize>,
+    remove_zeros: bool,
+    peak_removal: Option<f64>,
+) -> PyResult<PyQCResult> {
+    let qc_mode = match mode {
+        "all" => QCMode::All,
+        "isolation_tree" => QCMode::IsolationTree,
+        "mad" => QCMode::MAD,
+        "none" => QCMode::None,
+        other => {
+            return Err(PyValueError::new_err(format!(
+                "Unknown QC mode '{other}'. Use 'all', 'isolation_tree', 'mad', or 'none'."
+            )));
+        }
+    };
+
+    let data = DataFrameQCData {
+        df: df.0,
+        channel_ranges,
+    };
+
+    let config = PeacoQCConfig {
+        channels,
+        determine_good_cells: qc_mode,
+        min_cells,
+        max_bins,
+        events_per_bin,
+        mad,
+        it_limit,
+        consecutive_bins,
+        remove_zeros,
+        peak_removal: peak_removal.unwrap_or(1.0 / 3.0),
+        ..Default::default()
+    };
+
+    let result = peacoqc_rs::peacoqc(&data, &config).map_err(to_py_err)?;
+    Ok(PyQCResult { inner: result })
+}
+
+/// Remove margin events from flow cytometry data.
+///
+/// Margin events occur at detector saturation (min/max range boundaries).
+///
+/// Args:
+///     df: polars DataFrame with event data.
+///     channels: list of channel names to check.
+///     channel_ranges: dict mapping channel name to (min, max) range.
+///     remove_min: optional list of channels for minimum margin removal.
+///     remove_max: optional list of channels for maximum margin removal.
+///
+/// Returns:
+///     MarginResult with boolean mask and statistics.
+#[pyfunction]
+#[pyo3(signature = (df, channels, channel_ranges, remove_min = None, remove_max = None))]
+fn remove_margins(
+    df: PyDataFrame,
+    channels: Vec<String>,
+    channel_ranges: HashMap<String, (f64, f64)>,
+    remove_min: Option<Vec<String>>,
+    remove_max: Option<Vec<String>>,
+) -> PyResult<PyMarginResult> {
+    let data = DataFrameQCData {
+        df: df.0,
+        channel_ranges: channel_ranges.clone(),
+    };
+
+    let config = MarginConfig {
+        channels,
+        channel_specifications: Some(channel_ranges),
+        remove_min,
+        remove_max,
+    };
+
+    let result = peacoqc_rs::remove_margins(&data, &config).map_err(to_py_err)?;
+    Ok(PyMarginResult { inner: result })
+}
+
+/// Remove doublet events based on area/height scatter ratio.
+///
+/// Args:
+///     df: polars DataFrame with event data.
+///     channel_ranges: dict mapping channel name to (min, max) range.
+///     channel1: first channel name (default "FSC-A").
+///     channel2: second channel name (default "FSC-H").
+///     nmad: number of MADs above median for threshold (default 4.0).
+///     b: shift parameter (default 0.0).
+///
+/// Returns:
+///     DoubletResult with boolean mask and statistics.
+#[pyfunction]
+#[pyo3(signature = (df, channel_ranges, channel1 = "FSC-A", channel2 = "FSC-H", nmad = 4.0, b = 0.0))]
+fn remove_doublets(
+    df: PyDataFrame,
+    channel_ranges: HashMap<String, (f64, f64)>,
+    channel1: &str,
+    channel2: &str,
+    nmad: f64,
+    b: f64,
+) -> PyResult<PyDoubletResult> {
+    let data = DataFrameQCData {
+        df: df.0,
+        channel_ranges,
+    };
+
+    let config = DoubletConfig {
+        channel1: channel1.to_string(),
+        channel2: channel2.to_string(),
+        nmad,
+        b,
+    };
+
+    let result = peacoqc_rs::remove_doublets(&data, &config).map_err(to_py_err)?;
+    Ok(PyDoubletResult { inner: result })
+}
+
+/// Open an FCS file and return its data as a polars DataFrame.
+///
+/// This is a convenience function that opens an FCS file and returns
+/// the event data directly as a polars DataFrame.
+///
+/// Args:
+///     path: path to the FCS file.
+///
+/// Returns:
+///     polars DataFrame with event data.
+#[pyfunction]
+fn read_fcs(path: &str) -> PyResult<PyDataFrame> {
+    let fcs = flow_fcs::file::Fcs::open(path)
+        .map_err(|e| PyValueError::new_err(format!("Failed to open FCS file: {e}")))?;
+    let df = (*fcs.data_frame).clone();
+    Ok(PyDataFrame(df))
+}
+
+/// Open an FCS file, apply compensation and transformation, then run PeacoQC.
+///
+/// This is the highest-level convenience function that mirrors the typical
+/// R PeacoQC workflow:
+///   1. Open FCS file
+///   2. Apply compensation from $SPILLOVER
+///   3. Apply biexponential (or arcsinh) transformation
+///   4. Run PeacoQC on fluorescence channels
+///
+/// Args:
+///     path: path to the FCS file.
+///     channels: optional list of channels (auto-detects fluorescence channels if None).
+///     apply_compensation: apply compensation from $SPILLOVER (default True).
+///     apply_transformation: apply biexponential/arcsinh transform (default True).
+///     mode: QC mode - "all", "isolation_tree", "mad", or "none" (default "all").
+///     mad: MAD threshold multiplier (default 6.0).
+///     it_limit: Isolation Tree gain limit (default 0.6).
+///     consecutive_bins: minimum consecutive good bins (default 5).
+///
+/// Returns:
+///     Tuple of (QCResult, polars DataFrame of the preprocessed data).
+#[pyfunction]
+#[pyo3(signature = (
+    path,
+    channels = None,
+    apply_compensation = true,
+    apply_transformation = true,
+    mode = "all",
+    mad = 6.0,
+    it_limit = 0.6,
+    consecutive_bins = 5,
+))]
+#[allow(clippy::too_many_arguments)]
+fn run_qc_on_fcs(
+    path: &str,
+    channels: Option<Vec<String>>,
+    apply_compensation: bool,
+    apply_transformation: bool,
+    mode: &str,
+    mad: f64,
+    it_limit: f64,
+    consecutive_bins: usize,
+) -> PyResult<(PyQCResult, PyDataFrame)> {
+    let fcs = flow_fcs::file::Fcs::open(path)
+        .map_err(|e| PyValueError::new_err(format!("Failed to open FCS file: {e}")))?;
+
+    let fcs = peacoqc_rs::preprocess_fcs(fcs, apply_compensation, apply_transformation, 2000.0)
+        .map_err(anyhow_to_py_err)?;
+
+    let channels = channels.unwrap_or_else(|| fcs.get_fluorescence_channels());
+
+    let qc_mode = match mode {
+        "all" => QCMode::All,
+        "isolation_tree" => QCMode::IsolationTree,
+        "mad" => QCMode::MAD,
+        "none" => QCMode::None,
+        other => {
+            return Err(PyValueError::new_err(format!(
+                "Unknown QC mode '{other}'. Use 'all', 'isolation_tree', 'mad', or 'none'."
+            )));
+        }
+    };
+
+    let config = PeacoQCConfig {
+        channels,
+        determine_good_cells: qc_mode,
+        mad,
+        it_limit,
+        consecutive_bins,
+        apply_compensation: false, // already preprocessed
+        apply_transformation: false,
+        ..Default::default()
+    };
+
+    let result = peacoqc_rs::peacoqc(&fcs, &config).map_err(to_py_err)?;
+    let df = (*fcs.data_frame).clone();
+
+    Ok((PyQCResult { inner: result }, PyDataFrame(df)))
+}
+
+/// Open an FCS file as an FcsFile object for inspection and QC.
+///
+/// Args:
+///     path: path to the FCS file.
+///
+/// Returns:
+///     FcsFile object.
+#[pyfunction]
+fn open_fcs(path: &str) -> PyResult<PyFcsFile> {
+    PyFcsFile::open(path)
+}
+
+/// Run PeacoQC directly on an FcsFile object.
+///
+/// Args:
+///     fcs: FcsFile object (from open_fcs or FcsFile.open).
+///     channels: optional list of channels (auto-detects fluorescence channels if None).
+///     mode: QC mode (default "all").
+///     mad: MAD threshold multiplier (default 6.0).
+///     it_limit: Isolation Tree gain limit (default 0.6).
+///     consecutive_bins: minimum consecutive good bins (default 5).
+///
+/// Returns:
+///     QCResult.
+#[pyfunction]
+#[pyo3(signature = (fcs, channels = None, mode = "all", mad = 6.0, it_limit = 0.6, consecutive_bins = 5))]
+fn run_qc_on_fcs_obj(
+    fcs: &PyFcsFile,
+    channels: Option<Vec<String>>,
+    mode: &str,
+    mad: f64,
+    it_limit: f64,
+    consecutive_bins: usize,
+) -> PyResult<PyQCResult> {
+    let channels = channels.unwrap_or_else(|| fcs.inner.get_fluorescence_channels());
+
+    let qc_mode = match mode {
+        "all" => QCMode::All,
+        "isolation_tree" => QCMode::IsolationTree,
+        "mad" => QCMode::MAD,
+        "none" => QCMode::None,
+        other => {
+            return Err(PyValueError::new_err(format!(
+                "Unknown QC mode '{other}'. Use 'all', 'isolation_tree', 'mad', or 'none'."
+            )));
+        }
+    };
+
+    let config = PeacoQCConfig {
+        channels,
+        determine_good_cells: qc_mode,
+        mad,
+        it_limit,
+        consecutive_bins,
+        ..Default::default()
+    };
+
+    let result = peacoqc_rs::peacoqc(&fcs.inner, &config).map_err(to_py_err)?;
+    Ok(PyQCResult { inner: result })
+}
+
+/// Preprocess an FCS file (compensation + transformation) without running QC.
+///
+/// Args:
+///     fcs: FcsFile object.
+///     apply_compensation: apply $SPILLOVER compensation (default True).
+///     apply_transformation: apply biexponential/arcsinh transform (default True).
+///
+/// Returns:
+///     New FcsFile with preprocessed data.
+#[pyfunction]
+#[pyo3(signature = (fcs, apply_compensation = true, apply_transformation = true))]
+fn preprocess(
+    fcs: &PyFcsFile,
+    apply_compensation: bool,
+    apply_transformation: bool,
+) -> PyResult<PyFcsFile> {
+    let preprocessed = peacoqc_rs::preprocess_fcs(
+        fcs.inner.clone(),
+        apply_compensation,
+        apply_transformation,
+        2000.0,
+    )
+    .map_err(anyhow_to_py_err)?;
+    Ok(PyFcsFile { inner: preprocessed })
+}
+
+/// Filter an FcsFile by a boolean mask, returning a new FcsFile.
+///
+/// Args:
+///     fcs: FcsFile object.
+///     mask: list of booleans (True = keep).
+///
+/// Returns:
+///     Filtered FcsFile.
+#[pyfunction]
+fn filter_fcs(fcs: &PyFcsFile, mask: Vec<bool>) -> PyResult<PyFcsFile> {
+    let filtered = fcs.inner.filter(&mask).map_err(to_py_err)?;
+    Ok(PyFcsFile { inner: filtered })
+}
+
+// ---------------------------------------------------------------------------
+// Python module definition
+// ---------------------------------------------------------------------------
+
+#[pymodule]
+fn peacoqc(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<PyQCResult>()?;
+    m.add_class::<PyMarginResult>()?;
+    m.add_class::<PyDoubletResult>()?;
+    m.add_class::<PyFcsFile>()?;
+
+    m.add_function(wrap_pyfunction!(run_qc, m)?)?;
+    m.add_function(wrap_pyfunction!(remove_margins, m)?)?;
+    m.add_function(wrap_pyfunction!(remove_doublets, m)?)?;
+    m.add_function(wrap_pyfunction!(read_fcs, m)?)?;
+    m.add_function(wrap_pyfunction!(run_qc_on_fcs, m)?)?;
+    m.add_function(wrap_pyfunction!(open_fcs, m)?)?;
+    m.add_function(wrap_pyfunction!(run_qc_on_fcs_obj, m)?)?;
+    m.add_function(wrap_pyfunction!(preprocess, m)?)?;
+    m.add_function(wrap_pyfunction!(filter_fcs, m)?)?;
+
+    Ok(())
+}

--- a/peacoqc-py/tests/test_poc.py
+++ b/peacoqc-py/tests/test_poc.py
@@ -1,0 +1,323 @@
+"""
+Proof-of-concept: Test peacoqc Python bindings with synthetic flow cytometry data.
+
+This script exercises every major binding function using synthetic polars
+DataFrames that mimic typical flow cytometry event data.
+"""
+
+import polars as pl
+import peacoqc
+import math
+import random
+
+random.seed(42)
+
+
+def generate_synthetic_fcs_data(
+    n_events: int = 10_000,
+    n_bad_start: int = 500,
+    n_bad_end: int = 300,
+) -> pl.DataFrame:
+    """Generate synthetic flow cytometry event data with known quality issues.
+
+    Creates data with:
+    - A clean middle segment
+    - A degraded beginning (shifted mean = instrument warm-up)
+    - A degraded end (higher variance = clog/drift)
+    - Some margin events at detector boundaries
+    """
+    fl1 = []
+    fl2 = []
+    fsc_a = []
+    fsc_h = []
+
+    for i in range(n_events):
+        if i < n_bad_start:
+            # Warm-up: shifted distribution
+            fl1.append(random.gauss(30_000, 8_000))
+            fl2.append(random.gauss(25_000, 7_000))
+        elif i >= n_events - n_bad_end:
+            # Drift/clog: much wider distribution
+            fl1.append(random.gauss(50_000, 25_000))
+            fl2.append(random.gauss(45_000, 22_000))
+        else:
+            # Clean signal
+            fl1.append(random.gauss(50_000, 10_000))
+            fl2.append(random.gauss(45_000, 9_000))
+
+        # Scatter channels for doublet detection
+        base_fsc = random.gauss(100_000, 15_000)
+        fsc_a.append(base_fsc)
+        # Singlets: FSC-H ≈ FSC-A; doublets get a wider ratio
+        if random.random() < 0.03:
+            # ~3% doublet rate
+            fsc_h.append(base_fsc * random.gauss(0.6, 0.1))
+        else:
+            fsc_h.append(base_fsc * random.gauss(1.0, 0.05))
+
+    # Inject some margin events (at detector boundaries)
+    for idx in random.sample(range(n_events), min(50, n_events)):
+        fl1[idx] = 0.0  # minimum boundary
+    for idx in random.sample(range(n_events), min(30, n_events)):
+        fl2[idx] = 262_144.0  # maximum boundary
+
+    return pl.DataFrame({
+        "FSC-A": pl.Series(fsc_a, dtype=pl.Float32),
+        "FSC-H": pl.Series(fsc_h, dtype=pl.Float32),
+        "FL1-A": pl.Series(fl1, dtype=pl.Float32),
+        "FL2-A": pl.Series(fl2, dtype=pl.Float32),
+    })
+
+
+def test_run_qc():
+    """Test the main peacoqc QC pipeline."""
+    print("=" * 60)
+    print("TEST: run_qc (main PeacoQC pipeline)")
+    print("=" * 60)
+
+    df = generate_synthetic_fcs_data()
+    print(f"Input: {df.shape[0]} events, {df.shape[1]} channels")
+    print(f"Columns: {df.columns}")
+
+    channel_ranges = {
+        "FL1-A": (0.0, 262_144.0),
+        "FL2-A": (0.0, 262_144.0),
+    }
+
+    result = peacoqc.run_qc(
+        df,
+        channels=["FL1-A", "FL2-A"],
+        channel_ranges=channel_ranges,
+        mode="all",
+        mad=6.0,
+        it_limit=0.6,
+        consecutive_bins=5,
+    )
+
+    print(f"Result: {result}")
+    print(f"  good_cells length: {len(result.good_cells)}")
+    print(f"  percentage_removed: {result.percentage_removed:.2f}%")
+    print(f"  it_percentage: {result.it_percentage}")
+    print(f"  mad_percentage: {result.mad_percentage}")
+    print(f"  consecutive_percentage: {result.consecutive_percentage:.2f}%")
+    print(f"  n_bins: {result.n_bins}")
+    print(f"  events_per_bin: {result.events_per_bin}")
+
+    # Apply mask
+    good_mask = pl.Series(result.good_cells)
+    clean_df = df.filter(good_mask)
+    print(f"  Clean events: {clean_df.shape[0]} / {df.shape[0]}")
+
+    assert len(result.good_cells) == df.shape[0], "Mask length mismatch"
+    assert 0.0 <= result.percentage_removed <= 100.0, "Invalid percentage"
+    print("  PASSED\n")
+
+
+def test_run_qc_modes():
+    """Test different QC modes."""
+    print("=" * 60)
+    print("TEST: run_qc with different modes")
+    print("=" * 60)
+
+    df = generate_synthetic_fcs_data(n_events=5_000)
+    channel_ranges = {
+        "FL1-A": (0.0, 262_144.0),
+        "FL2-A": (0.0, 262_144.0),
+    }
+
+    for mode in ["all", "isolation_tree", "mad", "none"]:
+        result = peacoqc.run_qc(
+            df,
+            channels=["FL1-A", "FL2-A"],
+            channel_ranges=channel_ranges,
+            mode=mode,
+        )
+        print(f"  mode='{mode}': removed {result.percentage_removed:.2f}%")
+        assert len(result.good_cells) == df.shape[0]
+
+    print("  PASSED\n")
+
+
+def test_remove_margins():
+    """Test margin event removal."""
+    print("=" * 60)
+    print("TEST: remove_margins")
+    print("=" * 60)
+
+    df = generate_synthetic_fcs_data()
+    channel_ranges = {
+        "FL1-A": (0.0, 262_144.0),
+        "FL2-A": (0.0, 262_144.0),
+    }
+
+    result = peacoqc.remove_margins(
+        df,
+        channels=["FL1-A", "FL2-A"],
+        channel_ranges=channel_ranges,
+    )
+
+    print(f"Result: {result}")
+    print(f"  mask length: {len(result.mask)}")
+    print(f"  percentage_removed: {result.percentage_removed:.2f}%")
+    print(f"  margin_matrix: {result.margin_matrix}")
+
+    assert len(result.mask) == df.shape[0], "Mask length mismatch"
+    assert result.percentage_removed >= 0.0, "Negative percentage"
+
+    # Apply mask
+    clean_df = df.filter(pl.Series(result.mask))
+    print(f"  After margins: {clean_df.shape[0]} / {df.shape[0]}")
+    print("  PASSED\n")
+
+
+def test_remove_doublets():
+    """Test doublet removal."""
+    print("=" * 60)
+    print("TEST: remove_doublets")
+    print("=" * 60)
+
+    df = generate_synthetic_fcs_data()
+    channel_ranges = {
+        "FSC-A": (0.0, 262_144.0),
+        "FSC-H": (0.0, 262_144.0),
+    }
+
+    result = peacoqc.remove_doublets(
+        df,
+        channel_ranges=channel_ranges,
+        channel1="FSC-A",
+        channel2="FSC-H",
+        nmad=4.0,
+    )
+
+    print(f"Result: {result}")
+    print(f"  mask length: {len(result.mask)}")
+    print(f"  percentage_removed: {result.percentage_removed:.2f}%")
+    print(f"  median_ratio: {result.median_ratio:.4f}")
+    print(f"  mad_ratio: {result.mad_ratio:.4f}")
+    print(f"  threshold: {result.threshold:.4f}")
+
+    assert len(result.mask) == df.shape[0], "Mask length mismatch"
+    print("  PASSED\n")
+
+
+def test_full_pipeline():
+    """Test the complete QC pipeline: margins → doublets → PeacoQC."""
+    print("=" * 60)
+    print("TEST: Full pipeline (margins → doublets → QC)")
+    print("=" * 60)
+
+    df = generate_synthetic_fcs_data(n_events=10_000)
+    n_initial = df.shape[0]
+    print(f"Initial events: {n_initial}")
+
+    channel_ranges = {
+        "FSC-A": (0.0, 262_144.0),
+        "FSC-H": (0.0, 262_144.0),
+        "FL1-A": (0.0, 262_144.0),
+        "FL2-A": (0.0, 262_144.0),
+    }
+
+    # Step 1: Remove margins
+    margin_result = peacoqc.remove_margins(
+        df,
+        channels=["FL1-A", "FL2-A"],
+        channel_ranges=channel_ranges,
+    )
+    if margin_result.percentage_removed > 0:
+        df = df.filter(pl.Series(margin_result.mask))
+    print(f"After margins: {df.shape[0]} (removed {margin_result.percentage_removed:.2f}%)")
+
+    # Step 2: Remove doublets
+    doublet_result = peacoqc.remove_doublets(
+        df,
+        channel_ranges=channel_ranges,
+        channel1="FSC-A",
+        channel2="FSC-H",
+    )
+    if doublet_result.percentage_removed > 0:
+        df = df.filter(pl.Series(doublet_result.mask))
+    print(f"After doublets: {df.shape[0]} (removed {doublet_result.percentage_removed:.2f}%)")
+
+    # Step 3: Run PeacoQC
+    qc_result = peacoqc.run_qc(
+        df,
+        channels=["FL1-A", "FL2-A"],
+        channel_ranges=channel_ranges,
+        mode="all",
+    )
+    df = df.filter(pl.Series(qc_result.good_cells))
+    print(f"After PeacoQC: {df.shape[0]} (removed {qc_result.percentage_removed:.2f}%)")
+
+    total_removed = (1 - df.shape[0] / n_initial) * 100
+    print(f"Total pipeline removal: {total_removed:.2f}%")
+    print(f"Final clean events: {df.shape[0]} / {n_initial}")
+    print("  PASSED\n")
+
+
+def test_fcsfile_class():
+    """Test the FcsFile class (without an actual FCS file, just verify the class exists)."""
+    print("=" * 60)
+    print("TEST: FcsFile class availability")
+    print("=" * 60)
+
+    assert hasattr(peacoqc, "FcsFile"), "FcsFile class not found"
+    assert hasattr(peacoqc, "open_fcs"), "open_fcs function not found"
+    assert hasattr(peacoqc, "read_fcs"), "read_fcs function not found"
+    assert hasattr(peacoqc, "run_qc_on_fcs"), "run_qc_on_fcs function not found"
+    assert hasattr(peacoqc, "preprocess"), "preprocess function not found"
+    assert hasattr(peacoqc, "filter_fcs"), "filter_fcs function not found"
+    print("  All FCS-related exports present")
+    print("  PASSED\n")
+
+
+def test_error_handling():
+    """Test that errors are properly raised as Python exceptions."""
+    print("=" * 60)
+    print("TEST: Error handling")
+    print("=" * 60)
+
+    df = generate_synthetic_fcs_data(n_events=100)
+
+    # Invalid mode
+    try:
+        peacoqc.run_qc(df, channels=["FL1-A"], channel_ranges={}, mode="invalid")
+        assert False, "Should have raised ValueError"
+    except ValueError as e:
+        print(f"  Invalid mode error: {e}")
+
+    # Non-existent channel
+    try:
+        peacoqc.run_qc(
+            df,
+            channels=["NONEXISTENT"],
+            channel_ranges={"NONEXISTENT": (0.0, 100.0)},
+        )
+        assert False, "Should have raised ValueError"
+    except ValueError as e:
+        print(f"  Missing channel error: {e}")
+
+    # Non-existent FCS file
+    try:
+        peacoqc.open_fcs("/nonexistent/path.fcs")
+        assert False, "Should have raised ValueError"
+    except ValueError as e:
+        print(f"  Bad path error: {e}")
+
+    print("  PASSED\n")
+
+
+if __name__ == "__main__":
+    print("\n🧪 PeacoQC Python Bindings - Proof of Concept\n")
+
+    test_fcsfile_class()
+    test_error_handling()
+    test_run_qc()
+    test_run_qc_modes()
+    test_remove_margins()
+    test_remove_doublets()
+    test_full_pipeline()
+
+    print("=" * 60)
+    print("ALL TESTS PASSED")
+    print("=" * 60)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add PyO3 bindings to the `peacoqc-rs` library to enable its use in Python applications.

---
<p><a href="https://cursor.com/agents/bc-f831eadb-118f-4551-881c-1bcc3a470d45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f831eadb-118f-4551-881c-1bcc3a470d45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->