### PR TITLE
Kuva rendering API exposure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,6 +1453,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorous"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e18bf7a165bf7028fde98609a0f1e8f7498d762a212598e6c891f6893556ec"
+
+[[package]]
 name = "compact_str"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1653,6 +1659,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -2416,6 +2431,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
 name = "debug_unsafe"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2826,6 +2847,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
+name = "euclid"
+version = "0.22.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df61bf483e837f88d5c2291dcf55c67be7e676b3a51acc48db3a7b163b91ed63"
+dependencies = [
+ "num-traits 0.2.19",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3053,6 +3083,12 @@ dependencies = [
 
 [[package]]
 name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
+name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
@@ -3168,6 +3204,7 @@ dependencies = [
  "flow-fcs",
  "flow-utils",
  "image 0.25.9",
+ "kuva",
  "ndarray 0.16.1",
  "num-traits 0.2.19",
  "once_cell",
@@ -3258,6 +3295,39 @@ dependencies = [
  "walkdir",
  "winapi",
  "yeslogic-fontconfig-sys",
+]
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3a6f9af55fb97ad673fb7a69533eb2f967648a06fa21f8c9bb2cd6d33975716"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser 0.24.1",
+]
+
+[[package]]
+name = "fontdue"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e57e16b3fe8ff4364c0661fdaac543fb38b29ea9bc9c2f45612d90adf931d2b"
+dependencies = [
+ "hashbrown 0.15.5",
+ "ttf-parser 0.21.1",
 ]
 
 [[package]]
@@ -4454,7 +4524,7 @@ dependencies = [
  "color_quant",
  "exr",
  "gif 0.14.1",
- "image-webp",
+ "image-webp 0.2.4",
  "moxcms",
  "num-traits 0.2.19",
  "png 0.18.1",
@@ -4469,6 +4539,16 @@ dependencies = [
 
 [[package]]
 name = "image-webp"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79afb8cbee2ef20f59ccd477a218c12a93943d075b492015ecb1bb81f8ee904"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "image-webp"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
@@ -4476,6 +4556,12 @@ dependencies = [
  "byteorder-lite",
  "quick-error",
 ]
+
+[[package]]
+name = "imagesize"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
 name = "imgref"
@@ -4706,6 +4792,30 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "kurbo"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
+]
+
+[[package]]
+name = "kuva"
+version = "0.1.3"
+source = "git+https://github.com/jrmoynihan/kuva#2f6785a4e248e91361c89c71e51061cd16f2fe76"
+dependencies = [
+ "chrono",
+ "colorous",
+ "fontdue",
+ "rayon",
+ "resvg",
+ "ryu",
+]
 
 [[package]]
 name = "lapack-sys"
@@ -6192,6 +6302,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6234,7 +6350,7 @@ dependencies = [
  "plotters-backend",
  "plotters-bitmap",
  "plotters-svg",
- "ttf-parser",
+ "ttf-parser 0.20.0",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -7692,10 +7808,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "resvg"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a325d5e8d1cebddd070b13f44cec8071594ab67d1012797c121f27a669b7958"
+dependencies = [
+ "gif 0.13.3",
+ "image-webp 0.1.3",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+ "zune-jpeg 0.4.21",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "ring"
@@ -7735,6 +7871,12 @@ name = "robust"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rstar"
@@ -7910,6 +8052,24 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustybuzz"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85d1ccd519e61834798eb52c4e886e8c2d7d698dd3d6ce0b1b47eb8557f1181"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser 0.24.1",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
 
 [[package]]
 name = "ryu"
@@ -8255,6 +8415,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8468,6 +8637,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp 0.9.0",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8539,6 +8717,16 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "svgtypes"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
+dependencies = [
+ "kurbo",
+ "siphasher",
+]
 
 [[package]]
 name = "syn"
@@ -8834,6 +9022,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png 0.17.16",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
 ]
 
 [[package]]
@@ -9273,6 +9487,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
 
 [[package]]
+name = "ttf-parser"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
+
+[[package]]
+name = "ttf-parser"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be21190ff5d38e8b4a2d3b6a3ae57f612cc39c96e83cedeaf7abc338a8bac4a"
+dependencies = [
+ "core_maths",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9332,6 +9561,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64af057ad7466495ca113126be61838d8af947f41d93a949980b2389a118082f"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "260bc6647b3893a9a90668360803a15f96b85a5257b1c3a0c3daf6ae2496de42"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9347,6 +9594,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
 name = "unicode-reverse"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9354,6 +9607,12 @@ checksum = "4b6f4888ebc23094adfb574fdca9fdc891826287a6397d2cd28802ffd6f20c76"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
 
 [[package]]
 name = "unicode-segmentation"
@@ -9371,6 +9630,12 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width 0.1.14",
 ]
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "unicode-width"
@@ -9480,6 +9745,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "usvg"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7447e703d7223b067607655e625e0dbca80822880248937da65966194c4864e6"
+dependencies = [
+ "base64",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
+]
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9533,7 +9825,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e80f0c733af0720a501b3905d22e2f97662d8eacfe082a75ed7ffb5ab08cb59"
 dependencies = [
- "float-cmp",
+ "float-cmp 0.10.0",
  "halfbrown",
  "itoa",
  "ryu",
@@ -10529,6 +10821,12 @@ name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "xxhash-rust"

--- a/plots/Cargo.toml
+++ b/plots/Cargo.toml
@@ -17,6 +17,8 @@ categories=["science", "visualization"]
 
 [features]
 default=[]
+# Expose kuva rendering APIs (render_to_rgba, render_to_png_direct) for Tauri/zero-copy display
+raster = ["dep:kuva"]
 
 [dependencies]
 colormap      ="0.0.2"
@@ -34,6 +36,7 @@ once_cell     ="1.20"
 rayon         ={ workspace=true }
 num-traits    ="0.2"
 ndarray       ={ workspace=true }
+kuva          ={ git = "https://github.com/jrmoynihan/kuva", features = ["raster"], optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/plots/README.md
+++ b/plots/README.md
@@ -333,6 +333,23 @@ let plot_bytes = plot_bytes?;
 
 **Note**: While batch processing is available, sequential processing (calling `render()` in a loop) is typically faster for most use cases. See `GPU_EVALUATION.md` for performance analysis.
 
+## Kuva raster feature
+
+Enable the `raster` feature for kuva-based rendering APIs, useful for Tauri IPC and zero-copy canvas display:
+
+```toml
+flow-plots = { version = "...", features = ["raster"] }
+```
+
+| Function | Output | Use case |
+|----------|--------|----------|
+| `flow_plots::kuva::render_to_rgba` | `(width, height, Vec<u8>)` | Tauri IPC, `ImageData`, zero-copy canvas |
+| `flow_plots::kuva::render_to_rgba_no_text` | Same, no text | Fast preview, headless |
+| `flow_plots::kuva::render_to_png_direct` | PNG bytes | Direct raster, no SVG round-trip |
+| `flow_plots::kuva::render_to_png_direct_no_text` | PNG, no text | Fast PNG export |
+
+See [`flow_plots::kuva`] for Tauri command and frontend usage examples.
+
 ## Architecture
 
 The library is organized into several modules:

--- a/plots/src/kuva.rs
+++ b/plots/src/kuva.rs
@@ -1,0 +1,95 @@
+//! Kuva rendering APIs for Tauri/zero-copy display.
+//!
+//! Enabled with the `raster` feature. These functions render kuva plots to raw RGBA
+//! or PNG for use in Tauri IPC, web canvases, or other zero-copy display paths.
+//!
+//! ## Raster options
+//!
+//! | Function | Output | Use case |
+//! |----------|--------|----------|
+//! | [`render_to_rgba`] | `(width, height, Vec<u8>)` | Tauri IPC, `ImageData`, zero-copy canvas |
+//! | [`render_to_rgba_no_text`] | Same, no text | Fast preview, headless |
+//! | [`render_to_png_direct`] | PNG bytes | Direct raster, no SVG round-trip |
+//! | [`render_to_png_direct_no_text`] | PNG, no text | Fast PNG export |
+//!
+//! ## Example (Tauri)
+//!
+//! ```rust,ignore
+//! #[tauri::command]
+//! fn render_plot_rgba(plots: ..., layout: ..., scale: f32) -> Result<(u32, u32, Vec<u8>), String> {
+//!     flow_plots::kuva::render_to_rgba(plots, layout, scale)
+//! }
+//! ```
+//!
+//! Frontend:
+//!
+//! ```javascript
+//! const { width, height, data } = await invoke('render_plot_rgba', {...});
+//! const image_data = new ImageData(new Uint8ClampedArray(data), width, height);
+//! ctx.putImageData(image_data, 0, 0);
+//! ```
+
+#[cfg(feature = "raster")]
+pub use kuva::{
+    render_to_raster, render_to_raster_no_text,
+};
+
+/// Re-exported for building plots to pass to the render functions.
+#[cfg(feature = "raster")]
+pub use kuva::render::layout::Layout;
+/// Re-exported for building plots to pass to the render functions.
+#[cfg(feature = "raster")]
+pub use kuva::render::plots::Plot;
+
+/// Render kuva plots to raw RGBA `(width, height, data)` for zero-copy display.
+///
+/// Ideal for Tauri IPC and web canvas `ImageData` — no PNG encoding overhead.
+#[cfg(feature = "raster")]
+pub fn render_to_rgba(
+    plots: Vec<Plot>,
+    layout: Layout,
+    scale: f32,
+) -> Result<(u32, u32, Vec<u8>), String> {
+    let scene = kuva::render::render::render_multiple(plots, layout);
+    kuva::backend::raster::RasterBackend::new()
+        .with_scale(scale)
+        .render_scene_to_rgba(&scene)
+}
+
+/// Like [`render_to_rgba`] but skips text rendering for maximum throughput.
+#[cfg(feature = "raster")]
+pub fn render_to_rgba_no_text(
+    plots: Vec<Plot>,
+    layout: Layout,
+    scale: f32,
+) -> Result<(u32, u32, Vec<u8>), String> {
+    let scene = kuva::render::render::render_multiple(plots, layout);
+    kuva::backend::raster::RasterBackend::new()
+        .with_scale(scale)
+        .with_skip_text(true)
+        .render_scene_to_rgba(&scene)
+}
+
+/// Render kuva plots to PNG via direct raster (no SVG round-trip).
+///
+/// Alias for [`render_to_raster`].
+#[cfg(feature = "raster")]
+pub fn render_to_png_direct(
+    plots: Vec<Plot>,
+    layout: Layout,
+    scale: f32,
+) -> Result<Vec<u8>, String> {
+    kuva::render_to_raster(plots, layout, scale)
+}
+
+/// Like [`render_to_png_direct`] but skips text rendering.
+///
+/// Alias for [`render_to_raster_no_text`].
+#[cfg(feature = "raster")]
+pub fn render_to_png_direct_no_text(
+    plots: Vec<Plot>,
+    layout: Layout,
+    scale: f32,
+) -> Result<Vec<u8>, String> {
+    kuva::render_to_raster_no_text(plots, layout, scale)
+}

--- a/plots/src/lib.rs
+++ b/plots/src/lib.rs
@@ -49,6 +49,9 @@ pub mod scatter_data;
 pub mod render;
 pub mod signal_heatmap;
 
+#[cfg(feature = "raster")]
+pub mod kuva;
+
 // Re-export commonly used types
 pub use colormap::ColorMaps;
 pub use histogram_data::{HistogramData, HistogramDataError, HistogramSeries};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Expose new `render_to_rgba` and `render_to_png_direct` APIs from the `kuva` crate to enable raw RGBA output and direct raster PNG generation.

---
<p><a href="https://cursor.com/agents/bc-66ca97e6-53f7-49f4-b2ed-f768350d0c6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66ca97e6-53f7-49f4-b2ed-f768350d0c6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->